### PR TITLE
Fix bignum memory leak in boringssl branch

### DIFF
--- a/src/partially_blind_rsa.c
+++ b/src/partially_blind_rsa.c
@@ -487,6 +487,7 @@ pbrsa_derive_publickey_for_metadata(const PBRSAContext *context, PBRSAPublicKey 
         BN_free(e2);
         goto err;
     }
+    BN_free(e2);
 #else
     BIGNUM *e2 = BN_new();
     if (e2 == NULL || BN_bin2bn(exp_bytes, lambda_len, e2) == NULL) {


### PR DESCRIPTION
In the openssl [RSA_set0_key function](https://man.freebsd.org/cgi/man.cgi?query=RSA_set0_key), the function takes ownership of the parameters:
> Calling this	function
> transfers the memory management of the values to	the RSA	object,	and
> therefore the values that have been passed in should not	be freed by
> the caller after	this function has been called.

However, the boringssl equivalent [RSA_new_public_key_large_e](https://github.com/fastly/boringssl/blob/ab432fd40bc1579badfd24daeb0f068c2f86820d/crypto/fipsmodule/rsa/rsa.c.inc#L162-L177) copies its parameters:
```
RSA *RSA_new_public_key_large_e(const BIGNUM *n, const BIGNUM *e) {
  RSA *rsa = RSA_new();
  if (rsa == NULL) {
    return NULL;
  }

  rsa->flags |= RSA_FLAG_LARGE_PUBLIC_EXPONENT;
  if (!bn_dup_into(&rsa->n, n) ||  //
      !bn_dup_into(&rsa->e, e) ||  //
      !RSA_check_key(rsa)) {
    RSA_free(rsa);
    return NULL;
  }

  return rsa;
}
```

This means that we retain responsibility for memory management of `e2` and need to free it here.